### PR TITLE
Add more ido-like functionality

### DIFF
--- a/keymaps/closed.cson
+++ b/keymaps/closed.cson
@@ -17,3 +17,4 @@
   'ctrl-enter': 'closed:Open Current'
 '.closed-editor atom-text-editor[mini]':
   'tab': 'core:confirm'
+  'backspace': 'closed:Delete Filename'

--- a/lib/closed-view.coffee
+++ b/lib/closed-view.coffee
@@ -45,7 +45,7 @@ class ClosedView extends SelectListView
 
     atom.commands.add 'atom-workspace', 'closed:Open File': @show
     atom.commands.add '.closed-editor', 'closed:Open Current': @justOpen
-    atom.commands.add '.closed-editor', 'closed:Delete Filename': @deleteFilename
+    atom.commands.add '.closed-editor', 'closed:Delete Filename': @deleteFileNameCommand
 
   destroy: ->
     @remove()
@@ -70,14 +70,18 @@ class ClosedView extends SelectListView
     @panel.hide()
 
   # Remove the last level, file or directory, from the filter path
-  deleteFilename: =>
-    currentPath = @editor.getText()
+  deleteFilename: (path) ->
     newPath = ""
-    
-    matches = currentPath.match /(.*\/).+/
+    matches = path.match /(.*\/).+/
     if matches?
       [_, newPath] = matches
+    return newPath
+
+  deleteFileNameCommand: =>
+    currentPath = @editor.getText()
+    newPath = @deleteFilename(currentPath)
     @editor.setText(newPath)
+
 
 
   confirmed: ({basename, dir}) =>
@@ -94,7 +98,7 @@ class ClosedView extends SelectListView
     @panel.show()
     currentPath = atom.workspace.getActiveTextEditor()?.buffer?.file?.path;
     if(currentPath?)
-      @editor.setText(currentPath)
+      @editor.setText(@deleteFilename(currentPath))
 
     @storeFocusedElement()
     @focusFilterEditor()

--- a/lib/closed-view.coffee
+++ b/lib/closed-view.coffee
@@ -37,7 +37,6 @@ class ClosedView extends SelectListView
 
   initialize: ->
     super
-
     @editor = @filterEditorView.getModel()
     @editor.onDidChange @onChange
 
@@ -46,6 +45,7 @@ class ClosedView extends SelectListView
 
     atom.commands.add 'atom-workspace', 'closed:Open File': @show
     atom.commands.add '.closed-editor', 'closed:Open Current': @justOpen
+    atom.commands.add '.closed-editor', 'closed:Delete Filename': @deleteFilename
 
   destroy: ->
     @remove()
@@ -69,6 +69,17 @@ class ClosedView extends SelectListView
     @cancel()
     @panel.hide()
 
+  # Remove the last level, file or directory, from the filter path
+  deleteFilename: =>
+    currentPath = @editor.getText()
+    newPath = ""
+    
+    matches = currentPath.match /(.*\/).+/
+    if matches?
+      [_, newPath] = matches
+    @editor.setText(newPath)
+
+
   confirmed: ({basename, dir}) =>
     file = path.join(dir, basename)
     if @existsAndIsDir(file)
@@ -81,6 +92,9 @@ class ClosedView extends SelectListView
   show: =>
     @panel ?= atom.workspace.addModalPanel(item: this)
     @panel.show()
+    currentPath = atom.workspace.getActiveTextEditor()?.buffer?.file?.path;
+    if(currentPath?)
+      @editor.setText(currentPath)
 
     @storeFocusedElement()
     @focusFilterEditor()

--- a/lib/closed-view.coffee
+++ b/lib/closed-view.coffee
@@ -45,8 +45,7 @@ class ClosedView extends SelectListView
 
     atom.commands.add 'atom-workspace', 'closed:Open File': @show
     atom.commands.add '.closed-editor', 'closed:Open Current': @justOpen
-    atom.commands.add '.closed-editor', 'closed:Delete Filename': @deleteFileNameCommand
-
+    atom.commands.add '.closed-editor', 'closed:Delete Filename': @deleteFileName
   destroy: ->
     @remove()
 
@@ -70,16 +69,10 @@ class ClosedView extends SelectListView
     @panel.hide()
 
   # Remove the last level, file or directory, from the filter path
-  deleteFilename: (path) ->
-    newPath = ""
-    matches = path.match /(.*\/).+/
-    if matches?
-      [_, newPath] = matches
-    return newPath
 
-  deleteFileNameCommand: =>
+  deleteFileName: =>
     currentPath = @editor.getText()
-    newPath = @deleteFilename(currentPath)
+    newPath = path.normalize(path.dirname(currentPath) + path.sep)
     @editor.setText(newPath)
 
 
@@ -98,7 +91,9 @@ class ClosedView extends SelectListView
     @panel.show()
     currentPath = atom.workspace.getActiveTextEditor()?.buffer?.file?.path;
     if(currentPath?)
-      @editor.setText(@deleteFilename(currentPath))
-
+      @editor.setText(path.dirname(currentPath) + path.sep)
+    else
+      tilde '~', (home) =>
+        @editor.setText(home + path.sep)
     @storeFocusedElement()
     @focusFilterEditor()

--- a/lib/closed-view.coffee
+++ b/lib/closed-view.coffee
@@ -90,7 +90,7 @@ class ClosedView extends SelectListView
     @panel ?= atom.workspace.addModalPanel(item: this)
     @panel.show()
     currentPath = atom.workspace.getActiveTextEditor()?.buffer?.file?.path;
-    if(currentPath?)
+    if currentPath?
       @editor.setText(path.dirname(currentPath) + path.sep)
     else
       tilde '~', (home) =>


### PR DESCRIPTION
The following changes were made to make Closed work more similarly to the ido-mode 
- initialize the filter with the directory of the currently open file or empty string if no file open
  - assign backspace to the new command Delete Filename
  - add new command Delete Filename which deletes the last part of the filter's path
